### PR TITLE
Remove 'vignettes/' from .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,4 +6,3 @@
 ^LICENSE\.md$
 ^\.travis\.yml$
 ^\.github$
-vignettes/


### PR DESCRIPTION
So people can build the vignettes on install and browse with `browseVignettes("pbsEDM")` or, e.g., `vignette("pbsSmap")` as expected. (That also lets you link to them in the docs.) The vignettes seem to build fairly quickly. People would need to use:

```r
remotes::install_github("pbs-assess/pbsEDM", build_vignettes = TRUE)
```
which could possibly go in the readme.